### PR TITLE
Switch to requests

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -347,7 +347,7 @@ def fmt_status_message(payload=None):
 
 def shorten_url(url):
     try:
-        res = requests.post('http://git.io', 'url=' + url)
+        res = requests.post('https://git.io', 'url=' + url)
         return res.headers['location']
     except:
         return url

--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -17,8 +17,8 @@ Copyright 2015 Max Gurela
 from __future__ import unicode_literals
 
 import re
+import requests
 
-from sopel import web
 from sopel.formatting import color
 
 current_row = None
@@ -347,8 +347,8 @@ def fmt_status_message(payload=None):
 
 def shorten_url(url):
     try:
-        res, headers = web.post('http://git.io', 'url=' + web.quote(url), return_headers=True)
-        return headers['location']
+        res = requests.post('http://git.io', 'url=' + url)
+        return res.headers['location']
     except:
         return url
 

--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -11,7 +11,7 @@ Copyright 2015 Max Gurela
 """
 
 from __future__ import unicode_literals
-from sopel import web, tools
+from sopel import tools
 from sopel.module import commands, rule, OP, NOLIMIT, example, require_chanmsg
 from sopel.formatting import bold, color
 from sopel.tools.time import get_timezone, format_time
@@ -32,6 +32,7 @@ else:
     from urllib.parse import urlencode
     from urllib.error import HTTPError
 import json
+import requests
 import re
 import datetime
 
@@ -102,7 +103,7 @@ def fetch_api_endpoint(bot, url):
     oauth = ''
     if bot.config.github.client_id and bot.config.github.secret:
         oauth = '?client_id=%s&client_secret=%s' % (bot.config.github.client_id, bot.config.github.secret)
-    return web.get(url + oauth)
+    return requests.get(url + oauth).text
 
 
 @rule('.*%s.*' % issueURL)
@@ -243,8 +244,8 @@ def github_repo(bot, trigger, match=None):
             github.__version__, github.__author__, github.__repo__))
 
     if repo.lower() == 'status':
-        current = json.loads(web.get('https://status.github.com/api/status.json'))
-        lastcomm = json.loads(web.get('https://status.github.com/api/last-message.json'))
+        current = json.loads(requests.get('https://status.github.com/api/status.json').text)
+        lastcomm = json.loads(requests.get('https://status.github.com/api/last-message.json').text)
 
         status = current['status']
         if status == 'major':


### PR DESCRIPTION
Also updated the `git.io` shortlink fetcher to use HTTPS.

It's worth noting that the `web.post()` method in Sopel hasn't taken a `headers` kwarg for quite some time, so this module won't work with `sopel.web` any more.