### PR TITLE
fix: get_targets returned functions instead of channel list

### DIFF
--- a/sopel_modules/github/webhook.py
+++ b/sopel_modules/github/webhook.py
@@ -104,7 +104,7 @@ def get_targets(repo):
     conn = sopel_instance.db.connect()
     c = conn.cursor()
     c.execute('SELECT * FROM gh_hooks WHERE repo_name = ? AND enabled = 1', (repo.lower(), ))
-    return c.fetchall
+    return c.fetchall()
 
 
 @bottle.get("/webhook")


### PR DESCRIPTION
Adds in missing `()` at the end of `return c.fetchall`

:sob: @dgw broke it almost a year ago! :no_good_man: 
https://github.com/sopel-irc/sopel-github/blame/fee9b788739626b7fc976b8f69f2aca704930839/sopel_modules/github/webhook.py#L107