### PR TITLE
webhook: Handle PR reviews

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -335,6 +335,17 @@ def fmt_pull_request_review_summary_message(payload=None):
                   short)
 
 
+def fmt_pull_request_review_dismissal_message(payload=None):
+    if not payload:
+        payload = current_payload
+
+    return '[{}] {} dismissed {}\'s review on pull request #{}'.format(
+                  fmt_repo(payload['repository']['name']),
+                  fmt_name(payload['sender']['login']),
+                  fmt_name(payload['review']['user']['login']),
+                  payload['pull_request']['number'])
+
+
 def fmt_pull_request_review_comment_summary_message(payload=None):
     if not payload:
         payload = current_payload
@@ -449,6 +460,8 @@ def get_formatted_response(payload, row):
     elif payload['event'] == 'pull_request_review':
         if payload['action'] == 'submitted' and payload['review']['state'] != 'pending':
             messages.append(fmt_pull_request_review_summary_message() + " " + fmt_url(shorten_url(payload['review']['html_url'])))
+        elif payload['action'] == 'dismissed':
+            messages.append(fmt_pull_request_review_dismissal_message() + " " + fmt_url(shorten_url(payload['review']['html_url'])))
     elif payload['event'] == 'pull_request_review_comment' and payload['action'] == 'created':
         messages.append(fmt_pull_request_review_comment_summary_message() + " " + fmt_url(shorten_url(payload['comment']['html_url'])))
     elif payload['event'] == 'issues':

--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -463,7 +463,12 @@ def get_formatted_response(payload, row):
         elif re.match('(labeled|unlabeled)', payload['action']):
             messages.append(fmt_issue_label_message() + " " + fmt_url(shorten_url(payload['pull_request']['html_url'])))
     elif payload['event'] == 'pull_request_review':
-        if payload['action'] == 'submitted' and payload['review']['state'] != 'pending':
+        if payload['action'] == 'submitted' and payload['review']['state'] in ['approved', 'changes_requested', 'commented']:
+            if payload['review']['state'] == 'commented' and payload['review']['body'] == None:
+                # Probably an empty "review" fired by a pull_request_review_comment reply, which we'll get in a separate hook delivery.
+                # Wish GitHub didn't fire both events, but they do, even though it makes no sense.
+                # Either way, an empty review must be accompanied by comments, which will get handled when their hook(s) fire(s).
+                return
             messages.append(fmt_pull_request_review_summary_message() + " " + fmt_url(shorten_url(payload['review']['html_url'])))
         elif payload['action'] == 'dismissed':
             messages.append(fmt_pull_request_review_dismissal_message() + " " + fmt_url(shorten_url(payload['review']['html_url'])))

--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -468,8 +468,9 @@ def get_formatted_response(payload, row):
                 # Probably an empty "review" fired by a pull_request_review_comment reply, which we'll get in a separate hook delivery.
                 # Wish GitHub didn't fire both events, but they do, even though it makes no sense.
                 # Either way, an empty review must be accompanied by comments, which will get handled when their hook(s) fire(s).
-                return
-            messages.append(fmt_pull_request_review_summary_message() + " " + fmt_url(shorten_url(payload['review']['html_url'])))
+                pass
+            else:
+                messages.append(fmt_pull_request_review_summary_message() + " " + fmt_url(shorten_url(payload['review']['html_url'])))
         elif payload['action'] == 'dismissed':
             messages.append(fmt_pull_request_review_dismissal_message() + " " + fmt_url(shorten_url(payload['review']['html_url'])))
     elif payload['event'] == 'pull_request_review_comment' and payload['action'] == 'created':

--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -315,8 +315,10 @@ def fmt_pull_request_review_summary_message(payload=None):
         payload = current_payload
 
     action = payload['review']['state']
-    if re.match('(comment|request)', action):
-        action = action + ' on'
+    if action == 'commented':
+        action = 'left a review on'
+    elif action == 'changes_requested':
+        action = 'requested changes on'
 
     body = payload['review']['body']
     short = ''

--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -339,10 +339,15 @@ def fmt_pull_request_review_dismissal_message(payload=None):
     if not payload:
         payload = current_payload
 
-    return '[{}] {} dismissed {}\'s review on pull request #{}'.format(
+    if payload['sender']['login'] == payload['review']['user']['login']:
+        whose = 'their'
+    else:
+        whose = fmt_name(payload['review']['user']['login']) + '\'s'
+
+    return '[{}] {} dismissed {} review on pull request #{}'.format(
                   fmt_repo(payload['repository']['name']),
                   fmt_name(payload['sender']['login']),
-                  fmt_name(payload['review']['user']['login']),
+                  whose,
                   payload['pull_request']['number'])
 
 


### PR DESCRIPTION
GitHub doesn't list possible `state` values for the `review` object anywhere, but there's some weirdness around replies to PR review comment that this patch tries to handle.

Basically, a `commented` review with no body is just ignored, because an empty body means it _must_ have review comments that the existing handler will take care of when that event fires, separately. It's the only way to avoid getting two notifications in channel from the plugin whenever someone replies to a review comment, and comes at only the small expense of not firing off a review summary message to IRC if someone really does leave a `commented` review with only line notes and no top-level comment body.