### PR TITLE
webhook: ignore review comments when not "created"

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -381,7 +381,7 @@ def get_formatted_response(payload, row):
     elif payload['event'] == 'pull_request':
         if re.match('(open|close)', payload['action']):
             messages.append(fmt_pull_request_summary_message() + " " + fmt_url(shorten_url(payload['pull_request']['html_url'])))
-    elif payload['event'] == 'pull_request_review_comment':
+    elif payload['event'] == 'pull_request_review_comment' and payload['action'] == 'created':
         messages.append(fmt_pull_request_review_comment_summary_message() + " " + fmt_url(shorten_url(payload['comment']['html_url'])))
     elif payload['event'] == 'issues':
         if re.match('(open|close)', payload['action']):


### PR DESCRIPTION
Suppresses notifications for edits, etc.

Literally #16 but for `pull_request_review_comment` events instead.