### PR TITLE
webhook: Handle re-opening issues/PRs

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -384,12 +384,12 @@ def get_formatted_response(payload, row):
     elif payload['event'] == 'commit_comment':
         messages.append(fmt_commit_comment_summary() + " " + fmt_url(shorten_url(payload['comment']['html_url'])))
     elif payload['event'] == 'pull_request':
-        if re.match('(open|close)', payload['action']):
+        if re.match('((re)?open|clos)ed', payload['action']):
             messages.append(fmt_pull_request_summary_message() + " " + fmt_url(shorten_url(payload['pull_request']['html_url'])))
     elif payload['event'] == 'pull_request_review_comment':
         messages.append(fmt_pull_request_review_comment_summary_message() + " " + fmt_url(shorten_url(payload['comment']['html_url'])))
     elif payload['event'] == 'issues':
-        if re.match('(open|close)', payload['action']):
+        if re.match('((re)?open|clos)ed', payload['action']):
             messages.append(fmt_issue_summary_message() + " " + fmt_url(shorten_url(payload['issue']['html_url'])))
         elif re.match('(assigned|unassigned)', payload['action']):
             messages.append(fmt_issue_assignee_message() + " " + fmt_url(shorten_url(payload['issue']['html_url'])))


### PR DESCRIPTION
`re.match` is anchored at the beginning of the string. While this could have been done by switching to `re.search`, I think this approach is clearer — more explicit about what values are expected, and which should be ignored by the plugin.

This should be considered a bugfix as well as an enhancement, because right now the plugin only gives one side of the story if someone closes and reopens a pull request (such as sopel-irc/sopel#1542 just was, to fix a Travis-CI issue). Someone watching the IRC feed of events only would not know the PR was still active, and might think it had been rejected based on the closure.