### PR TITLE
formatting: Use `splitlines()`

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -190,7 +190,7 @@ def fmt_push_summary_message(payload=None, row=None):
 
 
 def fmt_commit_message(commit):
-    short = commit['message'].split('\n', 2)[0]
+    short = commit['message'].splitlines()[0]
     short = short + '...' if short != commit['message'] else short
 
     author = commit['author']['name']
@@ -205,7 +205,7 @@ def fmt_commit_comment_summary(payload=None, row=None):
     if not row:
         row = current_row
 
-    short = payload['comment']['body'].split('\r\n', 2)[0]
+    short = payload['comment']['body'].splitlines()[0]
     short = short + '...' if short != payload['comment']['body'] else short
     return '[{}] {} commented on commit {}: {}'.format(
                   fmt_repo(payload['repository']['name']),
@@ -262,7 +262,7 @@ def fmt_issue_comment_summary_message(payload=None):
         payload = current_payload
 
     issue_type = get_issue_type(payload)
-    short = payload['comment']['body'].split('\r\n', 2)[0]
+    short = payload['comment']['body'].splitlines()[0]
     short = short + '...' if short != payload['comment']['body'] else short
     return '[{}] {} commented on {} #{}: {}'.format(
                   fmt_repo(payload['repository']['name']),
@@ -296,7 +296,7 @@ def fmt_pull_request_summary_message(payload=None):
 def fmt_pull_request_review_comment_summary_message(payload=None):
     if not payload:
         payload = current_payload
-    short = payload['comment']['body'].split('\r\n', 2)[0]
+    short = payload['comment']['body'].splitlines()[0]
     short = short + '...' if short != payload['comment']['body'] else short
     sha1 = payload['comment']['commit_id']
     return '[{}] {} left a file comment in pull request #{} {}: {}'.format(

--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -120,12 +120,13 @@ def issue_info(bot, trigger, match=None):
         return NOLIMIT
     data = json.loads(raw)
     try:
-        if len(data['body'].split('\n')) > 1 and len(data['body'].split('\n')[0]) > 180:
-            body = data['body'].split('\n')[0] + '...'
-        elif len(data['body'].split('\n')) > 2 and len(data['body'].split('\n')[0]) < 180:
-            body = ' '.join(data['body'].split('\n')[:2]) + '...'
+        lines = data['body'].splitlines()
+        if len(lines) > 1 and len(lines[0]) > 180:
+            body = lines[0] + '...'
+        elif len(lines) > 2 and len(lines[0]) < 180:
+            body = ' '.join(lines[:2]) + '...'
         else:
-            body = data['body'].split('\n')[0]
+            body = lines[0]
     except (KeyError):
         bot.say('[GitHub] API says this is an invalid issue. Please report this if you know it\'s a correct link!')
         return NOLIMIT
@@ -164,10 +165,11 @@ def commit_info(bot, trigger, match=None):
         return NOLIMIT
     data = json.loads(raw)
     try:
-        if len(data['commit']['message'].split('\n')) > 1:
-            body = data['commit']['message'].split('\n')[0] + '...'
+        lines = data['commit']['message'].splitlines()
+        if len(lines) > 1:
+            body = lines[0] + '...'
         else:
-            body = data['commit']['message'].split('\n')[0]
+            body = lines[0]
     except (KeyError):
         bot.say('[GitHub] API says this is an invalid commit. Please report this if you know it\'s a correct link!')
         return NOLIMIT


### PR DESCRIPTION
Turns out that when someone comments via email, GitHub spits out a comment body containing just `\n` instead of `\r\n`. So by splitting issue/PR comments only on `\r\n`, we'd get a smushed-together mess only when someone commented by email—comments left via any browser on any platform would be fine.

The fix is straightforward: Any time we were using `.split('\r\n', 2)`, we just use `.splitlines()` instead. Index 0 of the resulting list is still going to be the first line.

Converted the commit-message handler also, even though those should (probably?) always be `\n`, just because it's better to be safe. Python handles all the newline sequences we could possibly need, so let's let it do the job for us.