### PR TITLE
Convert most `...`s to `…` (Unicode ellipsis)

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -206,7 +206,7 @@ def fmt_push_summary_message(payload=None, row=None):
 
 def fmt_commit_message(commit):
     short = commit['message'].splitlines()[0]
-    short = short + '...' if short != commit['message'] else short
+    short = short + '…' if short != commit['message'] else short
 
     author = commit['author']['name']
     sha = commit['id']
@@ -221,7 +221,7 @@ def fmt_commit_comment_summary(payload=None, row=None):
         row = current_row
 
     short = payload['comment']['body'].splitlines()[0]
-    short = short + '...' if short != payload['comment']['body'] else short
+    short = short + '…' if short != payload['comment']['body'] else short
     return '[{}] {} commented on commit {}: {}'.format(
                   fmt_repo(payload['repository']['name']),
                   fmt_name(payload['sender']['login']),
@@ -280,7 +280,7 @@ def fmt_issue_comment_summary_message(payload=None):
 
     issue_type = get_issue_type(payload)
     short = payload['comment']['body'].splitlines()[0]
-    short = short + '...' if short != payload['comment']['body'] else short
+    short = short + '…' if short != payload['comment']['body'] else short
     return '[{}] {} commented on {} #{}: {}'.format(
                   fmt_repo(payload['repository']['name']),
                   fmt_name(payload['sender']['login']),
@@ -314,7 +314,7 @@ def fmt_pull_request_review_comment_summary_message(payload=None):
     if not payload:
         payload = current_payload
     short = payload['comment']['body'].splitlines()[0]
-    short = short + '...' if short != payload['comment']['body'] else short
+    short = short + '…' if short != payload['comment']['body'] else short
     sha1 = payload['comment']['commit_id']
     return '[{}] {} left a file comment in pull request #{} {}: {}'.format(
                   fmt_repo(payload['repository']['name']),

--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -123,9 +123,9 @@ def issue_info(bot, trigger, match=None):
     try:
         lines = data['body'].splitlines()
         if len(lines) > 1 and len(lines[0]) > 180:
-            body = lines[0] + '...'
+            body = lines[0] + '…'
         elif len(lines) > 2 and len(lines[0]) < 180:
-            body = ' '.join(lines[:2]) + '...'
+            body = ' '.join(lines[:2]) + '…'
         elif len(lines) > 0:
             body = lines[0]
         else:
@@ -170,7 +170,7 @@ def commit_info(bot, trigger, match=None):
     try:
         lines = data['commit']['message'].splitlines()
         if len(lines) > 1:
-            body = lines[0] + '...'
+            body = lines[0] + '…'
         elif len(lines) > 0:
             body = lines[0]
         else:

--- a/sopel_modules/github/webhook.py
+++ b/sopel_modules/github/webhook.py
@@ -190,7 +190,7 @@ def handle_auth_response():
         title = 'Done!'
         header = 'Webhook setup complete!'
         body = 'That was simple, right?! You should be seeing a completion message in {} any second now'.format(channel)
-        flair = 'There\'s no way it was that easy... things are never this easy...'
+        flair = 'There\'s no way it was that easy… things are never this easy…'
     except Exception as e:
         title = 'Error!'
         header = 'Webhook setup failed!'


### PR DESCRIPTION
It usually looks way better than three standalone periods, and we really should take full advantage of Sopel's Unicode support.

Put in 0.2.0 just in case it might break someone's workflow because they're using some obscure environment that somehow can't handle this thing that even Python 2 has supported for years. (Actually, it's because changing the output except to fix a bug smells to me like "more than a patch release".)