### PR TITLE
Replace `SopelMemory.contains()` with `in` operator

### DIFF
--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -74,7 +74,7 @@ def configure(config):
 
 def setup(sopel):
     sopel.config.define_section('github', GitHubSection)
-    if not sopel.memory.contains('url_callbacks'):
+    if 'url_callbacks' not in sopel.memory:
         sopel.memory['url_callbacks'] = tools.SopelMemory()
     sopel.memory['url_callbacks'][regex] = issue_info
     sopel.memory['url_callbacks'][repoRegex] = data_url

--- a/sopel_modules/github/webhook.py
+++ b/sopel_modules/github/webhook.py
@@ -76,7 +76,7 @@ def create_table(bot, c):
 def shutdown_webhook(sopel):
     global sopel_instance
     sopel_instance = None
-    if sopel.memory.contains('gh_webhook_server'):
+    if 'gh_webhook_server' in sopel.memory:
         print('Stopping webhook server')
         sopel.memory['gh_webhook_server'].stop()
         sopel.memory['gh_webhook_thread'].join()


### PR DESCRIPTION
While the method has been deprecated for ages (since Willie 4?), it was only just recently "officially" marked as such in Sopel's master branch. Since using it after Sopel 7 comes out will produce a deprecation warning in Sopel's output, we should replace it.

This isn't super urgent, as this plugin's next (non-patch) version will drop _long_ before Sopel 7 is ready, but having it all set to merge is the goal here.