### PR TITLE
main: update regexes to match GitHub URL bits

### DIFF
--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -45,11 +45,18 @@ import datetime
 
 '''
 
-issueURL = (r'https?://(?:www\.)?github.com/([A-z0-9\-_]+/[A-z0-9\-_]+)/(?:issues|pull)/([\d]+)(?:#issuecomment-([\d]+))?')
-commitURL = (r'https?://(?:www\.)?github.com/([A-z0-9\-_]+/[A-z0-9\-_]+)/(?:commit)/([A-z0-9\-]+)')
+# GitHub enforces alphanumeric usernames, and allows only one punctuation character: hyphen ('-')
+# Regex copied and slightly modified to meet our needs from CC0 source:
+# https://github.com/shinnn/github-username-regex/blob/0794566cc10e8c5a0e562823f8f8e99fa044e5f4/module.js#L1
+githubUsername = r'[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}'
+# not from anywhere, but handy to simply reuse
+githubRepoSlug = r'[A-Za-z0-9\.\-]+'
+# lots of regex and other globals to make this stuff work
+issueURL = (r'https?://(?:www\.)?github.com/({username}/{repo})/(?:issues|pull)/([\d]+)(?:#issuecomment-([\d]+))?'.format(username=githubUsername, repo=githubRepoSlug))
+commitURL = (r'https?://(?:www\.)?github.com/({username}/{repo})/(?:commit)/([A-z0-9\-]+)'.format(username=githubUsername, repo=githubRepoSlug))
 regex = re.compile(issueURL)
 commitRegex = re.compile(commitURL)
-repoRegex = re.compile(r'github\.com/([^ /]+?)/([^ /]+)/?(?!\S)')
+repoRegex = re.compile(r'github\.com/({username})/({repo})/?(?!\S)'.format(username=githubUsername, repo=githubRepoSlug))
 sopel_instance = None
 
 

--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -48,8 +48,9 @@ import datetime
 # GitHub enforces alphanumeric usernames, and allows only one punctuation character: hyphen ('-')
 # Regex copied and slightly modified to meet our needs from CC0 source:
 # https://github.com/shinnn/github-username-regex/blob/0794566cc10e8c5a0e562823f8f8e99fa044e5f4/module.js#L1
-githubUsername = r'[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}'
-# not from anywhere, but handy to simply reuse
+githubUsername = r'[A-Za-z\d](?:[A-Za-z\d]|-(?=[A-Za-z\d])){0,38}'
+# GitHub additionally allows dots ('.') in repo names, as well as hyphens
+# not copied from anywhere, but handy to simply reuse
 githubRepoSlug = r'[A-Za-z0-9\.\-]+'
 # lots of regex and other globals to make this stuff work
 issueURL = (r'https?://(?:www\.)?github.com/({username}/{repo})/(?:issues|pull)/([\d]+)(?:#issuecomment-([\d]+))?'.format(username=githubUsername, repo=githubRepoSlug))


### PR DESCRIPTION
The username and repo name regexes weren't exactly accurate. They allowed underscore (`_`) which GitHub will not, and did not accept dot (`.`) in repo names even though GitHub allows that. (This was discovered by posting a link to Sopel's website, whose repo is named `sopel.chat`, and noting that the GitHub module didn't handle it as expected.)

With a bit of Google searching and some tweaks, we should have much more robust URL matching now.

This has been running for almost two weeks in our "official" Sopel instance on freenode, FWIW.