### PR TITLE
formatting: Use Oxford comma in comma-ized arrays

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -338,7 +338,10 @@ def fmt_gollum_summary_message(payload=None):
 
 
 def fmt_arr_to_sentence(array):
-    return '{} and {}'.format(', '.join(array[:-1]), array[-1])
+    if len(seq) <= 2:
+        return ' and '.join(seq)
+    else:
+        return '{}, and {}'.format(', '.join(seq[:-1]), seq[-1])
 
 
 def fmt_watch_message(payload=None):


### PR DESCRIPTION
Inspired by @half-duplex's tongue-in-cheek complaint on IRC.

I would have put this into 0.1.7 if it had come up in time, but I'm not planning to make a 0.1.8 release. So I guess this gets to wait until 0.2.0.