### PR TITLE
Fix setting name: `secret` -> `client_secret`

### DIFF
--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -56,6 +56,7 @@ sopel_instance = None
 class GitHubSection(StaticSection):
     client_id = ValidatedAttribute('client_id', default=None)
     client_secret = ValidatedAttribute('client_secret', default=None)
+    secret = ValidatedAttribute('secret', default=None)  # TODO remove in 0.3.0 or thereabouts
     webhook = ValidatedAttribute('webhook', bool, default=False)
     webhook_host = ValidatedAttribute('webhook_host', default='0.0.0.0')
     webhook_port = ValidatedAttribute('webhook_port', default='3333')
@@ -83,6 +84,13 @@ def setup(sopel):
 
     if sopel.config.github.webhook:
         setup_webhook(sopel)
+
+    if not sopel.config.github.client_secret:
+        if sopel.config.github.secret:
+            sopel.config.github.client_secret = sopel.config.github.secret
+            del sopel.config.github.secret
+            sopel.config.save()
+            tools.stderr("[GitHub] Migrated `secret` to `client_secret` in config.")
 
 
 def shutdown(sopel):

--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -55,8 +55,8 @@ sopel_instance = None
 
 class GitHubSection(StaticSection):
     client_id = ValidatedAttribute('client_id', default=None)
-    secret    = ValidatedAttribute('secret', default=None)
-    webhook   = ValidatedAttribute('webhook', bool, default=False)
+    client_secret = ValidatedAttribute('client_secret', default=None)
+    webhook = ValidatedAttribute('webhook', bool, default=False)
     webhook_host = ValidatedAttribute('webhook_host', default='0.0.0.0')
     webhook_port = ValidatedAttribute('webhook_port', default='3333')
     external_url = ValidatedAttribute('external_url', default='http://your_ip_or_domain_here:3333')
@@ -65,8 +65,8 @@ class GitHubSection(StaticSection):
 def configure(config):
     config.define_section('github', GitHubSection, validate=False)
     config.github.configure_setting('client_id', 'GitHub API Client ID')
-    config.github.configure_setting('secret',    'GitHub API Client Secret')
-    config.github.configure_setting('webhook',   'Enable webhook listener functionality')
+    config.github.configure_setting('client_secret', 'GitHub API Client Secret')
+    config.github.configure_setting('webhook', 'Enable webhook listener functionality')
     if config.github.webhook:
         config.github.configure_setting('webhook_host', 'Listen IP for incoming webhooks (0.0.0.0 for all IPs)')
         config.github.configure_setting('webhook_port', 'Listen port for incoming webhooks')
@@ -102,8 +102,8 @@ def shutdown(sopel):
 
 def fetch_api_endpoint(bot, url):
     oauth = ''
-    if bot.config.github.client_id and bot.config.github.secret:
-        oauth = '?client_id=%s&client_secret=%s' % (bot.config.github.client_id, bot.config.github.secret)
+    if bot.config.github.client_id and bot.config.github.client_secret:
+        oauth = '?client_id=%s&client_secret=%s' % (bot.config.github.client_id, bot.config.github.client_secret)
     return requests.get(url + oauth).text
 
 


### PR DESCRIPTION
Includes automatic migration, which we can leave in for the life of 0.2.x and then remove in 0.3.0. (Note to self: Create issue or preemptive PR for removing the migration after merging this.)