### PR TITLE
formatting: truncate comments at 250 characters

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -18,6 +18,8 @@ Copyright 2019 dgw
 from __future__ import unicode_literals
 
 import re
+import textwrap
+
 import requests
 
 from sopel.formatting import color
@@ -71,8 +73,8 @@ def fmt_branch(s, row=None):
 
 def fmt_short_comment_body(body):
     text = [line for line in body.splitlines() if line and line[0] != '>']
-    short = text[0]
-    short = short + '…' if short != body else short
+    short = textwrap.wrap(text[0], 250)[0]
+    short = short + ' […]' if short != body else short
     return short
 
 


### PR DESCRIPTION
Long comment lines will no longer push the link off the end of Sopel's output line, hooray!