### PR TITLE
formatting: extra whitespace != truncated comment

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -72,7 +72,7 @@ def fmt_branch(s, row=None):
 
 
 def fmt_short_comment_body(body):
-    lines = [line for line in body.splitlines() if line and line[0] != '>']
+    lines = [line.strip() for line in body.splitlines() if line and line[0] != '>']
     short = textwrap.wrap(lines[0], 250)[0]
     if len(lines) > 1 or short != lines[0]:
         short += ' […]'


### PR DESCRIPTION
A one-line comment with extra surrounding whitespace would trigger adding `[…]` to the "shortened" comment even if the line wasn't truncated. That's wrong.