### PR TITLE
Ignore HTML-style comments and Markdown headings in comment shortener

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -72,7 +72,14 @@ def fmt_branch(s, row=None):
 
 
 def fmt_short_comment_body(body):
-    lines = [line.strip() for line in body.splitlines() if line and line[0] != '>']
+    lines = [
+        line.strip()
+        for line in body.splitlines()
+        if line
+        and line[0] != '>'  # Markdown quote
+        and not line.startswith('#')  # Markdown heading
+        and not line.startswith('<!-')  # commented out HTML-style
+    ]
     short = textwrap.wrap(lines[0], 250)[0]
     if len(lines) > 1 or short != lines[0]:
         short += ' […]'

--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -139,15 +139,7 @@ def issue_info(bot, trigger, match=None):
         return NOLIMIT
     data = json.loads(raw)
     try:
-        lines = data['body'].splitlines()
-        if len(lines) > 1 and len(lines[0]) > 180:
-            body = lines[0] + '…'
-        elif len(lines) > 2 and len(lines[0]) < 180:
-            body = ' '.join(lines[:2]) + '…'
-        elif len(lines) > 0:
-            body = lines[0]
-        else:
-            body = ''
+        body = formatting.fmt_short_comment_body(data['body'])
     except (KeyError):
         bot.say('[GitHub] API says this is an invalid issue. Please report this if you know it\'s a correct link!')
         return NOLIMIT


### PR DESCRIPTION
We now ignore lines that look like Markdown quotations (leading `>`), Markdown headings (one or more leading `#`), and HTML-style comments (leading `<!--`). None of these makes for a particularly useful snippet when sent to IRC, so we exclude them.