### PR TITLE
Sopel 7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ printing details of:
  * Issues
  * Issue Comments
  * Pull Requests
+ * Pull Request Comments
  * Repositories
 
-Pretty prints repository details on command, using `.gh user/repo` or `.github
-user/repo`. If you omit the user, it will assume your IRC nick is the user. For
-example:
+Also pretty prints repository details on command, using either `.gh user/repo`
+or `.github user/repo`. If you omit the user, it will assume your IRC nick is
+the user. For example:
 
 ```
 <@maxpowa> .gh sopel-github
@@ -42,29 +43,35 @@ example:
         | Watchers: 1 | Forks: 8 | Network: 8 | Open Issues: 18 |
         https://github.com/sopel-irc/sopel-github
 ```
-If you have [the `emoji` package](https://pypi.org/project/emoji/) installed, `:emoji_name:`s will be converted to Unicode emoji in the output.
+
+If you have [the `emoji` package](https://pypi.org/project/emoji/) installed,
+most `:emoji_name:`s will be converted to Unicode emoji in the output. (GitHub
+supports some non-standard names that this plugin doesn't handle yet.)
 
 
 ### API Keys & Usage
 
-GitHub APIs have some fairly lenient unauthorized request limits, but you may
+GitHub's API has some fairly lenient unauthorized request limits, but you may
 find yourself hitting them. In order to prevent yourself from hitting these
-limits (and potentially being blacklisted), you should generate GitHub API keys
-for yourself. Fill out the information at
+limits (and potentially being blacklisted), you should generate GitHub API
+keys for yourself. Fill out the information at
 https://github.com/settings/applications/new and then populate your
 configuration with your newly generated client key and secret.
 
-__IF YOU PLAN ON USING WEBHOOK FUNCTIONALITY:__ You _must_ properly fill out the
-"Authorization callback URL" to match the external URL you plan to use for the
-webhook.
+__IF YOU PLAN ON USING WEBHOOK FUNCTIONALITY:__ You _must_ properly fill out
+the "Authorization callback URL" to match the external URL you plan to use for
+the webhook.
 
 
 ## Webhook Functionality
 
 Webhook functionality is __disabled__ by default. It requires slightly more
-technical knowledge and configuration may vary depending on your system. There's
-two ways this may be configured, behind a proxy or exposed to the web.
+technical knowledge and configuration may vary depending on your system.
 
+### Configuring Webhooks
+
+There are two possible ways to set this up: behind a proxy or directly exposed
+to the web.
 
 #### Configuring behind a proxy
 
@@ -73,6 +80,7 @@ there may be security flaws in the other method.
 
 First, configure the GitHub module. You may do so by running `sopel
 --configure-modules` or changing the config file directly.
+
 ```
 [github]
 webhook = True
@@ -80,21 +88,23 @@ webhook_host = 127.0.0.1
 webhook_port = 3333
 external_url = http://bad.code.brought.to.you.by.maxpowa.us/webhook
 ```
+
 The above configuration is only listening on `localhost (127.0.0.1)`, because
-I'm using a reverse proxy in nginx to proxy `/webhook` to port 3333. The reverse
-proxy configuration would be fairly simple, as shown below. Auth must be
-included, to match the "Authorization callback URL" you included in generating
-the API keys.
+I'm using a reverse proxy in nginx to proxy `/webhook` to port 3333. The
+reverse proxy configuration would be fairly simple, as shown below. `/auth`
+must be included to match the "Authorization callback URL" you set when
+generating the API keys.
+
 ```
 location ~ /(webhook|auth) {
     proxy_pass http://127.0.0.1:3333;
 }
-``` 
+```
 
 #### Configuring exposed to the web
 
-If you're not using a proxy, your config will look something like the below
-config.
+If you're not using a proxy, your config will look something like this:
+
 ```
 [github]
 webhook = True
@@ -106,9 +116,9 @@ external_url = http://your.ip.here:3333/webhook
 ### Creating hooks
 
 As an OP+ in a channel, you may type `.gh-hook user/repo`. You will see some
-informational text on what you need to do to finalize the hook, including a link
-to click to authorize the creation of the webhook. You will be required to
-authorize the GitHub application to read/write your webhooks (see
+informational text on what you need to do to finalize the hook, including a
+link to click to authorize the creation of the webhook. You will be required
+to authorize the GitHub application to read/write your webhooks (see
 [L163-164](https://github.com/sopel-irc/sopel-github/blob/9afaf1e51d9c28a1bbba7b442f6e7dea7db74018/sopel_modules/github/webhook.py#L163-L164))
 but this should be the _only_ permissions we need.
 
@@ -123,10 +133,10 @@ but this should be the _only_ permissions we need.
         configure the colors that I use to display webhooks with .gh-hook-color
 ```
 
-After you've authorized the webhook creation, you will be redirected to a simple
-page informing you that the bot succeeded/failed creating your hook. Assuming it
-succeeded, you should see a generic message appear in the channel you activated
-it in.
+After you've authorized the webhook creation, you will be redirected to a
+simple page informing you that the bot succeeded/failed creating your hook.
+Assuming it succeeded, you should see a generic message appear in the channel
+you activated it in.
 
 
 ### Customizing hooks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sopel>=6.0,<7
-bottle
+sopel>=7.0,<8
+bottle~=0.12.0

--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -13,7 +13,7 @@ Copyright 2019 dgw
 
 from __future__ import unicode_literals
 from sopel import tools
-from sopel.module import commands, rule, OP, NOLIMIT, example, require_chanmsg
+from sopel.module import OP, NOLIMIT, commands, example, require_chanmsg, url
 from sopel.formatting import bold, color
 from sopel.tools.time import get_timezone, format_time
 from sopel.config.types import StaticSection, ValidatedAttribute
@@ -57,10 +57,6 @@ baseURL = r'https?://(?:www\.)?github.com/({username}/{repo})'.format(username=g
 repoURL = baseURL + r'/?(?!\S)'
 issueURL = baseURL + r'/(?:issues|pull)/([\d]+)(?:#issuecomment-([\d]+))?'
 commitURL = baseURL + r'/(?:commit)/([A-z0-9\-]+)'
-repoRegex = re.compile(repoURL)
-issueRegex = re.compile(issueURL)
-commitRegex = re.compile(commitURL)
-sopel_instance = None
 
 
 class GitHubSection(StaticSection):
@@ -86,11 +82,6 @@ def configure(config):
 
 def setup(sopel):
     sopel.config.define_section('github', GitHubSection)
-    if 'url_callbacks' not in sopel.memory:
-        sopel.memory['url_callbacks'] = tools.SopelMemory()
-    sopel.memory['url_callbacks'][repoRegex] = repo_info
-    sopel.memory['url_callbacks'][issueRegex] = issue_info
-    sopel.memory['url_callbacks'][commitRegex] = commit_info
 
     if sopel.config.github.webhook:
         setup_webhook(sopel)
@@ -104,9 +95,6 @@ def setup(sopel):
 
 
 def shutdown(sopel):
-    del sopel.memory['url_callbacks'][repoRegex]
-    del sopel.memory['url_callbacks'][issueRegex]
-    del sopel.memory['url_callbacks'][commitRegex]
     shutdown_webhook(sopel)
 
 '''
@@ -125,7 +113,7 @@ def fetch_api_endpoint(bot, url):
     return requests.get(url + oauth).text
 
 
-@rule('.*%s.*' % issueURL)
+@url(issueURL)
 def issue_info(bot, trigger, match=None):
     match = match or trigger
     URL = 'https://api.github.com/repos/%s/issues/%s' % (match.group(1), match.group(2))
@@ -174,7 +162,7 @@ def issue_info(bot, trigger, match=None):
     bot.say(''.join(response))
 
 
-@rule('.*%s.*' % commitURL)
+@url(commitURL)
 def commit_info(bot, trigger, match=None):
     match = match or trigger
     URL = 'https://api.github.com/repos/%s/commits/%s' % (match.group(1), match.group(2))
@@ -254,7 +242,7 @@ def get_data(bot, trigger, URL):
     return data
 
 
-@rule('.*%s.*' % repoURL)
+@url(repoURL)
 def repo_info(bot, trigger):
     user, repo = [s.strip() for s in trigger.group(1).split('/', 1)]
     URL = 'https://api.github.com/repos/%s/%s' % (user, repo)


### PR DESCRIPTION
* Use Sopel 7's fixed `@url` decorator
* Drop manual management of URL callback functions (taken care of for us by the decorator)
* Bump required Sopel version range
* Update/tweak README

Using the `@url` decorator should fix #7 (or most of it) since Sopel performs a punctuation-trimming step on URLs before processing them. It'll also mean more than one issue/PR, user, or repo link can be handled per IRC line (a shortcoming of the `@rule` approach we used in Sopel 6.x, in which `@url` was unreliable—it wouldn't work if the built-in `url.py` plugin was disabled).