### PR TITLE
github: handle null commit author w/fallback to Git data

### DIFF
--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -206,7 +206,7 @@ def commit_info(bot, trigger, match=None):
         ' [',
         match.group(1),
         '] ',
-        data['author']['login'],
+        data['author']['login'] if data['author'] else data['commit']['author']['name'],
         ': ',
         body,
         bold(' | '),


### PR DESCRIPTION
GitHub's API response for a commit handily includes a `commit` key with the raw author/committer data as displayed in Git, which we can use if the `author` is `null` at the GitHub level (i.e. no user matching the email address used in Git).

Fixes #55.

Demo comparing my production bot (running sopel-github 0.2.6) and test bot (running this patch):

```
<~dgw> https://github.com/sopel-irc/sopel/commit/30cddb270c0223db09f81a0cb7fc9f195ecfd0b3
<&Kaede> Unexpected error ('NoneType' object is not subscriptable) from dgw at 2020-02-02
         02:46:30.988810. Message was:
         https://github.com/sopel-irc/sopel/commit/30cddb270c0223db09f81a0cb7fc9f195ecfd0b3
<SopelTest> [GitHub] [sopel-irc/sopel] Michael Yanovich: initial commit | 10767 changes in
            142 files
```