### PR TITLE
Replace deprecated calls to `msg()` with `say()`

### DIFF
--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -348,7 +348,7 @@ def configure_repo_messages(bot, trigger):
     '''
     allowed = bot.privileges[trigger.sender].get(trigger.nick, 0) >= OP
     if not allowed and not trigger.admin:
-        return bot.msg(trigger.sender, 'You must be a channel operator to use this command!')
+        return bot.say('You must be a channel operator to use this command!')
 
     if not trigger.group(2):
         return bot.say(configure_repo_messages.__doc__.strip())
@@ -396,7 +396,7 @@ def configure_repo_colors(bot, trigger):
     '''
     allowed = bot.privileges[trigger.sender].get(trigger.nick, 0) >= OP
     if not allowed and not trigger.admin:
-        return bot.msg(trigger.sender, 'You must be a channel operator to use this command!')
+        return bot.say('You must be a channel operator to use this command!')
 
     if not trigger.group(2):
         return bot.say(configure_repo_colors.__doc__.strip())

--- a/sopel_modules/github/webhook.py
+++ b/sopel_modules/github/webhook.py
@@ -111,17 +111,17 @@ def get_targets(repo):
 def process_payload(payload, targets):
     if payload['event'] == 'ping':
         for row in targets:
-            sopel_instance.msg(row[0], '[{}] {}: {} (Your webhook is now enabled)'.format(
+            sopel_instance.say('[{}] {}: {} (Your webhook is now enabled)'.format(
                           fmt_repo(payload['repository']['name'], row),
                           fmt_name(payload['sender']['login'], row),
-                          payload['zen']))
+                          payload['zen']), row[0])
         return
 
     for row in targets:
         messages = get_formatted_response(payload, row)
         # Write the formatted message(s) to the channel
         for message in messages:
-            sopel_instance.msg(row[0], message)
+            sopel_instance.say(message, row[0])
 
 
 @bottle.get("/webhook")


### PR DESCRIPTION
The proverbial `bot.msg()` has been deprecated since Sopel 6. In Sopel 7, using it emits warnings to the log. It's time we modernized how this plugin talks.