### PR TITLE
github: fix trigger groups in `.gh` command

### DIFF
--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -283,8 +283,12 @@ def repo_info(bot, trigger, match=None):
 
 
 @commands('github', 'gh')
+@example('.gh sopel-irc/sopel-github')
 def github_repo(bot, trigger):
-    repo = trigger.group(2) or trigger.group(1)
+    repo = trigger.group(3) or None
+
+    if repo is None:
+        return bot.reply('I need a repository name, or `user/reponame`.')
 
     if repo.lower() == 'version':
         return bot.say('[GitHub] Version {} by {}, report issues at {}'.format(


### PR DESCRIPTION
I have no idea why this was using a fallback to group 1 (the command name) instead of just detecting an empty/missing group 2 (or 3).

Now instead of a generic "Not found" error for missing argument, caused by looking for a repo at `<nick>/<command_name>`, we have a proper usage reply and an example decorator.