### PR TITLE
webhook: fix error on reconnect

### DIFF
--- a/sopel_modules/github/webhook.py
+++ b/sopel_modules/github/webhook.py
@@ -99,6 +99,7 @@ class StoppableWSGIRefServer(bottle.ServerAdapter):
 
     def stop(self):
         self.server.shutdown()
+        self.server.server_close()
 
 
 def get_targets(repo):


### PR DESCRIPTION
The bot runs plugin `shutdown`s on disconnect from the IRC server. While
this method stops serving requests it doesn't actually close the socket; 
thus, the "restarted" webserver cannot bind to the same host/port in order 
to listen+serve requests. This results in a `OSError: [Errno 98] Address 
already in use`. The server needs to be closed after `shutdown`.

**edit**: As of this commit, the fix is valid for _all supported_ Python ~~>=2.7,>=3.5~~.