### PR TITLE
webhook: Handle issue transfers

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -277,6 +277,23 @@ def fmt_issue_incoming_transfer_message(payload=None):
                   emojize(payload['issue']['title']))
 
 
+def fmt_issue_outgoing_transfer_message(payload=None):
+    if not payload:
+        payload = current_payload
+    # For "transferred" events (sent for the source repo only), GitHub DOES set
+    # the "sender" info to the user who initiated the transfer, unlike for
+    # inbound transfer hooks (which just look like any other "opened" event
+    # except for the addition of a "changes" object).
+    return '[{}] {} transferred issue #{} by {} to {}#{}: {}'.format(
+                  fmt_repo(payload['repository']['name']),
+                  fmt_name(payload['sender']['login']),
+                  payload['issue']['number'],
+                  fmt_name(payload['issue']['user']['login']),
+                  fmt_repo(payload['changes']['new_repository']['full_name']),
+                  payload['changes']['new_issue']['number'],
+                  emojize(payload['issue']['title']))
+
+
 def fmt_issue_title_edit(payload=None):
     if not payload:
         payload = current_payload
@@ -577,6 +594,8 @@ def get_formatted_response(payload, row):
             if 'changes' in payload:
                 if 'title' in payload['changes']:
                     messages.append(fmt_issue_title_edit() + " " + fmt_url(shorten_url(payload['issue']['html_url'])))
+        elif payload['action'] == 'transferred':
+            messages.append(fmt_issue_outgoing_transfer_message() + " " + fmt_url(shorten_url(payload['changes']['new_issue']['html_url'])))
     elif payload['event'] == 'issue_comment' and payload['action'] == 'created':
         messages.append(fmt_issue_comment_summary_message() + " " + fmt_url(shorten_url(payload['comment']['html_url'])))
     elif payload['event'] == 'gollum':


### PR DESCRIPTION
I dislike using the presence of certain dict keys to guess whether an issue was natively created vs. transferred in, but GitHub ties my hands on that. There's also no workaround for determining who actually transferred the incoming issue; that data just _isn't included_.

At least issues transferred _out_ have a distinct "action" type and proper "sender" info, thankfully…

_[As an aside: The more features that get added to the webhook handler here, the more obvious it is that GitHub's webhook payloads are not very well thought-out in places, especially when newer site features from the last few years are involved.]_