### PR TITLE
formatting: handle 'converted_to_draft' PR event

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -352,6 +352,8 @@ def fmt_pull_request_summary_message(payload=None):
         action = 'drafted'
     elif action == 'ready_for_review':
         action = 'readied'
+    elif action == 'converted_to_draft':
+        action = 'un-readied'
 
     return '[{}] {} {} pull request #{}: {} ({}...{})'.format(
                   fmt_repo(payload['repository']['name']),
@@ -518,7 +520,7 @@ def get_formatted_response(payload, row):
     elif payload['event'] == 'commit_comment':
         messages.append(fmt_commit_comment_summary() + " " + fmt_url(shorten_url(payload['comment']['html_url'])))
     elif payload['event'] == 'pull_request':
-        if re.match('((re)?open|clos)ed', payload['action']) or payload['action'] == 'ready_for_review':
+        if re.match('((re)?open|clos)ed', payload['action']) or payload['action'] in ['ready_for_review', 'converted_to_draft']:
             messages.append(fmt_pull_request_summary_message() + " " + fmt_url(shorten_url(payload['pull_request']['html_url'])))
         elif payload['action'] == 'edited':
             if 'changes' in payload:


### PR DESCRIPTION
Bless GitHub for adding the ability to change your mind about a PR being ready for review, but of course it does require handling in this plugin to show up in activity feeds.

Hopefully this won't cause any merge conflict with #69, which I forgot about until now.