### PR TITLE
formatting: fix double space in webhook output for self-assignments

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -325,15 +325,18 @@ def fmt_issue_title_edit(payload=None):
 def fmt_issue_assignee_message(payload=None):
     if not payload:
         payload = current_payload
-    
+
     target = ''
+    assignee = payload['assignee']['login']
     self_assign = False
-    if (payload['assignee']['login'] == payload['sender']['login']):
+
+    if assignee == payload['sender']['login']:
         self_assign = True
     else:
-        target = 'to ' if payload['action'] == 'assigned' else 'from '
-        target = target + fmt_name(payload['assignee']['login']) 
-    return '[{}] {} {}{} {} #{} {} ({})'.format(
+        prep = 'to' if payload['action'] == 'assigned' else 'from'
+        target = ' {} {}'.format(prep, fmt_name(assignee))
+
+    return '[{}] {} {}{} {} #{}{} ({})'.format(
                   fmt_repo(payload['repository']['name']),
                   fmt_name(payload['sender']['login']),
                   'self-' if self_assign else '',


### PR DESCRIPTION
Tin. Pretty big diff for a tiny little change, and I really want to refactor the code now. Don't have time to do it, but I want to.

Note: Needs a formal test before merging, if I'm not too lazy.