### PR TITLE
github: output link for numeric issue/PR references

### DIFF
--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -176,6 +176,12 @@ def issue_info(bot, trigger, match=None):
         response.append(bold(' | '))
     response.append(emojize(body))
 
+    # append link, if not triggered by a link
+    if not match:
+        link = shorten_url(data['html_url'])
+        response.append(bold(' | '))
+        response.append(link)
+
     bot.say(''.join(response))
 
 


### PR DESCRIPTION
Closes #84. This was _trivial_ compared to what I thought I'd have to do (mess with the `formatting` submodule). Fancy having everything I needed already there in the `issue_info()` function…