### PR TITLE
github: skip URL handling for links under special site sections

### DIFF
--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -49,7 +49,10 @@ import base64
 # GitHub enforces alphanumeric usernames, and allows only one punctuation character: hyphen ('-')
 # Regex copied and slightly modified to meet our needs from CC0 source:
 # https://github.com/shinnn/github-username-regex/blob/0794566cc10e8c5a0e562823f8f8e99fa044e5f4/module.js#L1
-githubUsername = r'[A-Za-z\d](?:[A-Za-z\d]|-(?=[A-Za-z\d])){0,38}'
+githubUsername = (
+    r'(?!(?:collections|events|sponsors|topics|trending)/)'  # exclude special sections
+    r'[A-Za-z\d](?:[A-Za-z\d]|-(?=[A-Za-z\d])){0,38}'
+)
 # GitHub additionally allows dots ('.') in repo names, as well as hyphens
 # not copied from anywhere, but handy to simply reuse
 githubRepoSlug = r'[A-Za-z0-9\.\-]+'


### PR DESCRIPTION
Trending, events, collections, etc. are not real users and generate "Not Found" if their URLs happen to match the format of e.g. a repo URL. We can skip them and let the built-in title plugin do it.

Resolves #96.