### PR TITLE
formatting: improve comment body shortener

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -75,6 +75,9 @@ def fmt_branch(s, row=None):
 
 
 def fmt_short_comment_body(body):
+    if body is None or body.strip() == '':
+        return '(empty comment)'
+
     lines = [
         line.strip()
         for line in body.splitlines()
@@ -83,6 +86,10 @@ def fmt_short_comment_body(body):
         and not line.startswith('#')  # Markdown heading
         and not line.startswith('<!-')  # commented out HTML-style
     ]
+    # if there's nothing left, the comment is "empty"
+    if not lines:
+        return '(no body text)'
+
     # abbreviate commit hashes in the text
     line = re.sub(r'[a-f0-9]{40}', lambda m: m.group(0)[:7], lines[0])
     # wrap text to get a line of at most 250 chars

--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -163,10 +163,7 @@ def issue_info(bot, trigger, match=None):
         bot.say('[GitHub] API says this is an invalid issue. Please report this if you know it should work!')
         return NOLIMIT
 
-    if body is None or body.strip() == '':
-        body = 'No description provided.'
-    else:
-        body = formatting.fmt_short_comment_body(body)
+    body = formatting.fmt_short_comment_body(body)
 
     # what we have so far
     response = [


### PR DESCRIPTION
This eliminates the weird split between callers that handle an empty comment body themselves (in `github.py`) and callers that just blindly pass the comment body into `fmt_short_comment_body` and take whatever comes back.

Now, everyone expects `fmt_short_comment_body()` to do something sensible, even if the comment is empty or consists only of skippable lines (headers, comments, quotes).