### PR TITLE
formatting: remove `shorten_url()`

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -20,8 +20,6 @@ from __future__ import unicode_literals
 import re
 import textwrap
 
-import requests
-
 from sopel.formatting import color
 from sopel import tools
 
@@ -568,15 +566,6 @@ def fmt_release_message(payload=None):
         ' (prerelease)' if payload['release']['prerelease'] else '')
 
 
-def shorten_url(url):
-    try:
-        res = requests.post('https://git.io', {'url': url})
-        return res.headers['location']
-    except:
-        LOGGER.exception('Shortening link failed; using long URL.')
-        return url
-
-
 def get_formatted_response(payload, row):
     global current_row, current_payload
     current_payload = payload
@@ -584,25 +573,25 @@ def get_formatted_response(payload, row):
 
     messages = []
     if payload['event'] == 'push':
-        messages.append(fmt_push_summary_message() + " " + fmt_url(shorten_url(get_push_summary_url())))
+        messages.append(fmt_push_summary_message() + " " + fmt_url(get_push_summary_url()))
         for commit in get_distinct_commits():
             messages.append(fmt_commit_message(commit))
     elif payload['event'] == 'commit_comment':
-        messages.append(fmt_commit_comment_summary() + " " + fmt_url(shorten_url(payload['comment']['html_url'])))
+        messages.append(fmt_commit_comment_summary() + " " + fmt_url(payload['comment']['html_url']))
     elif payload['event'] == 'pull_request':
         if re.match('((re)?open|clos)ed', payload['action']) or payload['action'] in ['ready_for_review', 'converted_to_draft']:
-            messages.append(fmt_pull_request_summary_message() + " " + fmt_url(shorten_url(payload['pull_request']['html_url'])))
+            messages.append(fmt_pull_request_summary_message() + " " + fmt_url(payload['pull_request']['html_url']))
         elif payload['action'] == 'edited':
             if 'changes' in payload:
                 if 'title' in payload['changes']:
-                    messages.append(fmt_pull_request_title_edit() + " " + fmt_url(shorten_url(payload['pull_request']['html_url'])))
+                    messages.append(fmt_pull_request_title_edit() + " " + fmt_url(payload['pull_request']['html_url']))
         elif re.match('(assigned|unassigned)', payload['action']):
-            messages.append(fmt_issue_assignee_message() + " " + fmt_url(shorten_url(payload['pull_request']['html_url'])))
+            messages.append(fmt_issue_assignee_message() + " " + fmt_url(payload['pull_request']['html_url']))
         elif re.match('(labeled|unlabeled)', payload['action']):
             if payload.get('label', None):
                 # If a label is deleted, for example, we'll get a webhook payload with no details about the removed label.
                 # We skip those; there's no reason to emit action messages to IRC with "unknown label" placeholders.
-                messages.append(fmt_issue_label_message() + " " + fmt_url(shorten_url(payload['pull_request']['html_url'])))
+                messages.append(fmt_issue_label_message() + " " + fmt_url(payload['pull_request']['html_url']))
     elif payload['event'] == 'pull_request_review':
         if payload['action'] == 'submitted' and payload['review']['state'] in ['approved', 'changes_requested', 'commented']:
             if payload['review']['state'] == 'commented' and payload['review']['body'] == None:
@@ -611,37 +600,37 @@ def get_formatted_response(payload, row):
                 # Either way, an empty review must be accompanied by comments, which will get handled when their hook(s) fire(s).
                 pass
             else:
-                messages.append(fmt_pull_request_review_summary_message() + " " + fmt_url(shorten_url(payload['review']['html_url'])))
+                messages.append(fmt_pull_request_review_summary_message() + " " + fmt_url(payload['review']['html_url']))
         elif payload['action'] == 'dismissed':
-            messages.append(fmt_pull_request_review_dismissal_message() + " " + fmt_url(shorten_url(payload['review']['html_url'])))
+            messages.append(fmt_pull_request_review_dismissal_message() + " " + fmt_url(payload['review']['html_url']))
     elif payload['event'] == 'pull_request_review_comment' and payload['action'] == 'created':
-        messages.append(fmt_pull_request_review_comment_summary_message() + " " + fmt_url(shorten_url(payload['comment']['html_url'])))
+        messages.append(fmt_pull_request_review_comment_summary_message() + " " + fmt_url(payload['comment']['html_url']))
     elif payload['event'] == 'issues':
         if re.match('((re)?open|clos)ed', payload['action']):
             if 'changes' in payload and all(k in payload['changes'] for k in ['old_repository', 'old_issue']):
-                messages.append(fmt_issue_incoming_transfer_message() + " " + fmt_url(shorten_url(payload['issue']['html_url'])))
+                messages.append(fmt_issue_incoming_transfer_message() + " " + fmt_url(payload['issue']['html_url']))
             else:
-                messages.append(fmt_issue_summary_message() + " " + fmt_url(shorten_url(payload['issue']['html_url'])))
+                messages.append(fmt_issue_summary_message() + " " + fmt_url(payload['issue']['html_url']))
         elif re.match('(assigned|unassigned)', payload['action']):
-            messages.append(fmt_issue_assignee_message() + " " + fmt_url(shorten_url(payload['issue']['html_url'])))
+            messages.append(fmt_issue_assignee_message() + " " + fmt_url(payload['issue']['html_url']))
         elif re.match('(labeled|unlabeled)', payload['action']):
             if payload.get('label', None):
                 # If a label is deleted, for example, we'll get a webhook payload with no details about the removed label.
                 # We skip those; there's no reason to emit action messages to IRC with "unknown label" placeholders.
-                messages.append(fmt_issue_label_message() + " " + fmt_url(shorten_url(payload['issue']['html_url'])))
+                messages.append(fmt_issue_label_message() + " " + fmt_url(payload['issue']['html_url']))
         elif re.match('(milestoned|demilestoned)', payload['action']):
-            messages.append(fmt_issue_milestone_message() + " " + fmt_url(shorten_url(payload['issue']['html_url'])))
+            messages.append(fmt_issue_milestone_message() + " " + fmt_url(payload['issue']['html_url']))
         elif payload['action'] == 'edited':
             if 'changes' in payload:
                 if 'title' in payload['changes']:
-                    messages.append(fmt_issue_title_edit() + " " + fmt_url(shorten_url(payload['issue']['html_url'])))
+                    messages.append(fmt_issue_title_edit() + " " + fmt_url(payload['issue']['html_url']))
         elif payload['action'] == 'transferred':
-            messages.append(fmt_issue_outgoing_transfer_message() + " " + fmt_url(shorten_url(payload['changes']['new_issue']['html_url'])))
+            messages.append(fmt_issue_outgoing_transfer_message() + " " + fmt_url(payload['changes']['new_issue']['html_url']))
     elif payload['event'] == 'issue_comment' and payload['action'] == 'created':
-        messages.append(fmt_issue_comment_summary_message() + " " + fmt_url(shorten_url(payload['comment']['html_url'])))
+        messages.append(fmt_issue_comment_summary_message() + " " + fmt_url(payload['comment']['html_url']))
     elif payload['event'] == 'gollum':
         url = payload['pages'][0]['html_url'] if len(payload['pages']) else payload['repository']['url'] + '/wiki'
-        messages.append(fmt_gollum_summary_message() + " " + fmt_url(shorten_url(url)))
+        messages.append(fmt_gollum_summary_message() + " " + fmt_url(url))
     elif payload['event'] == 'watch':
         messages.append(fmt_watch_message())
     elif payload['event'] == 'status':
@@ -649,6 +638,6 @@ def get_formatted_response(payload, row):
     elif payload['event'] == 'release':
         if payload['action'] == 'published':
             # Currently the only possible action, but other events might eventually fire webhooks too
-            messages.append(fmt_release_message() + " " + fmt_url(shorten_url(payload['release']['html_url'])))
+            messages.append(fmt_release_message() + " " + fmt_url(payload['release']['html_url']))
 
     return messages

--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -19,7 +19,7 @@ from sopel.tools.time import get_timezone, format_time
 from sopel.config.types import StaticSection, ValidatedAttribute
 
 from . import formatting
-from .formatting import shorten_url, emojize
+from .formatting import emojize
 from .webhook import setup_webhook, shutdown_webhook
 
 import operator
@@ -224,9 +224,8 @@ def issue_info(bot, trigger, match=None):
 
     # append link, if not triggered by a link
     if not match:
-        link = shorten_url(data['html_url'])
         response.append(bold(' | '))
-        response.append(link)
+        response.append(data['html_url'])
 
     bot.say(''.join(response))
 
@@ -519,13 +518,15 @@ def configure_repo_messages(bot, trigger):
     if not result:
         c.execute('''INSERT INTO gh_hooks (channel, repo_name, enabled) VALUES (?, ?, ?)''', (channel, repo_name, enabled))
         bot.say("Successfully enabled listening for {repo}'s events in {chan}.".format(chan=channel, repo=repo_name))
-        bot.say('Great! Please allow me to create my webhook by authorizing via this link: ' + shorten_url(auth_url))
+        bot.say('Great! Please allow me to create my webhook by authorizing via this link:')
+        bot.say(auth_url, max_messages=10)
         bot.say('Once that webhook is successfully created, I\'ll post a message in here. Give me about a minute or so to set it up after you authorize. You can configure the colors that I use to display webhooks with {}gh-hook-color'.format(bot.config.core.help_prefix))
     else:
         c.execute('''UPDATE gh_hooks SET enabled = ? WHERE channel = ? AND repo_name = ?''', (enabled, channel, repo_name))
         bot.say("Successfully {state} the subscription to {repo}'s events".format(state='enabled' if enabled else 'disabled', repo=repo_name))
         if enabled:
-            bot.say('Great! Please allow me to create my webhook by authorizing via this link: ' + shorten_url(auth_url))
+            bot.say('Great! Please allow me to create my webhook by authorizing via this link:')
+            bot.say(auth_url, max_messages=10)
             bot.say('Once that webhook is successfully created, I\'ll post a message in here. Give me about a minute or so to set it up after you authorize. You can configure the colors that I use to display webhooks with {}gh-hook-color'.format(bot.config.core.help_prefix))
     conn.commit()
     conn.close()


### PR DESCRIPTION
It hasn't been doing anything useful for a while anyway, since GitHub killed off their git.io shortening service.

Now that we definitely expect the full link, the `.gh-hook` command will output the authorization URL on its own line, with `max_messages` set to allow Sopel to split it across multiple messages if needed. Truncation would be very bad in that case.

Resolves #102.