### PR TITLE
formatting: fix ref field names

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -116,18 +116,13 @@ def get_distinct_commits(payload=None):
 def get_ref_name(payload=None):
     if not payload:
         payload = current_payload
-
-    if 'ref_name' in payload:
-        return payload['ref_name']
-
-    payload['ref_name'] = re.sub(r'^refs/(heads|tags)/', '', payload['ref'])
-    return payload['ref_name']
+    return re.sub(r'^refs/(heads|tags)/', '', payload['ref'])
 
 
 def get_base_ref_name(payload=None):
     if not payload:
         payload = current_payload
-    return re.sub(r'^refs/(heads|tags)/', '', payload['base_ref_name'])
+    return re.sub(r'^refs/(heads|tags)/', '', payload['base_ref'])
 
 
 def get_pusher(payload=None):


### PR DESCRIPTION
After pushing v0.4.7 and SSHing into the main Sopel instance for Libera (to update the plugin there), I saw that the console log showed a KeyError for `base_ref_name` in the push handler. Lo and behold, GitHub's webhook documentation makes no mention of that or the `ref_name` field.

It's clearly been a while since this code was touched (sometime before Max split things into multiple files). Consulting Wayback Machine caches of the old developer.github.com doesn't actually show me any payload examples with the field names that were in the code here. Maybe this stuff was always broken, and no one noticed because hardly anyone:

  1) uses webhooks; and
  2) sends Sopel the push event type

That's my guess. This is an obscure feature of the plugin, certainly.

**Still to do:**

- proper testing
- check for other incorrect field names