### PR TITLE
formatting: use `emoji` 2.0 style

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ the user. For example:
 If you have [the `emoji` package](https://pypi.org/project/emoji/) installed,
 most `:emoji_name:`s will be converted to Unicode emoji in the output. (GitHub
 supports some non-standard names that this plugin doesn't handle yet.)
+This feature requires emoji >= 1.7, but >= 2.0 is recommended:
+```
+pip install 'emoji>=2.0'
+```
 
 
 ### API Keys & Usage

--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -28,7 +28,7 @@ try:
 except ImportError:
     emojize = lambda text: text
 else:
-    emojize = lambda text: emoji.emojize(text, use_aliases=True)
+    emojize = lambda text: emoji.emojize(text, language='alias')
 
 current_row = None
 current_payload = None


### PR DESCRIPTION
use language='alias' instead of use_aliases=True, which was deprecated in 1.7.0,
see also: https://github.com/carpedm20/emoji/blob/v1.7.0/emoji/core.py

Pretty straight forward change. Let me know if there is anything else that I can/should do, since I already have the fork open.