### PR TITLE
github: send API version header

### DIFF
--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -123,7 +123,7 @@ def fetch_api_endpoint(bot, url):
     auth = None
     if bot.config.github.client_id and bot.config.github.client_secret:
         auth = (bot.config.github.client_id, bot.config.github.client_secret)
-    return requests.get(url, auth=auth).text
+    return requests.get(url, headers={'X-GitHub-Api-Version': '2022-11-28'}, auth=auth).text
 
 
 @plugin.find(r'(?<!\S)/?#(\d+)\b')


### PR DESCRIPTION
https://docs.github.com/en/rest/overview/api-versions#about-api-versioning

This is for future-proofing. Occasionally the plugin's been broken by API changes that we weren't prepared for (I, at least, am not very good about keeping on top of announcements), and this way we are explicitly declaring which version we want and gaining a 24-month grace period to adapt after a new version is released.