### PR TITLE
github: simplify getting PR merge status

### DIFF
--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -188,21 +188,12 @@ def issue_info(bot, trigger, match=None):
         # if it's a link directly to the issue/PR, things are more complicated
         type_ = 'issue'
         state = data['state']
+
         if 'pull_request' in data:
             type_ = 'PR'
 
-        if type_ == 'PR' and state == 'closed':
-            # annoying consequence of "all PRs are issues, but not all issues are PRs"
-            # merge status is only included if the object is fetched via `pulls` endpoint
-            try:
-                pr_raw = fetch_api_endpoint(bot, data['pull_request']['url'])
-            except HTTPError:
-                # just use the "issue" state, fine
-                pass
-
-            pr_data = json.loads(pr_raw)
-            if pr_data.get("merged"):
-                state = "merged"
+            if state == 'closed' and data['pull_request'].get('merged_at'):
+                state = 'merged'
 
         response.extend([
             state,


### PR DESCRIPTION
`merged_at` is `null` if the PR is either open, or closed unmerged.

Not 100% certain that field is guaranteed to be populated for *every* PR on GitHub, regardless of age, but I think it's acceptable to get rid of the second API request in exchange for a small risk of giving slightly incorrect output in a very small number of cases.