### PR TITLE
github: remove obsolete `secret` setting

### DIFF
--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -70,7 +70,6 @@ contentURL = baseURL + r'/(?:blob|raw)/([^/\s]+)/([^#\s]+)(?:#L(\d+)(?:-L(\d+))?
 class GitHubSection(StaticSection):
     client_id = ValidatedAttribute('client_id', default=None)
     client_secret = ValidatedAttribute('client_secret', default=None)
-    secret = ValidatedAttribute('secret', default=None)  # TODO remove in 0.3.0 or thereabouts
     webhook = ValidatedAttribute('webhook', bool, default=False)
     webhook_host = ValidatedAttribute('webhook_host', default='0.0.0.0')
     webhook_port = ValidatedAttribute('webhook_port', default='3333')
@@ -93,13 +92,6 @@ def setup(sopel):
 
     if sopel.config.github.webhook:
         setup_webhook(sopel)
-
-    if not sopel.config.github.client_secret:
-        if sopel.config.github.secret:
-            sopel.config.github.client_secret = sopel.config.github.secret
-            del sopel.config.github.secret
-            sopel.config.save()
-            tools.stderr("[GitHub] Migrated `secret` to `client_secret` in config.")
 
 
 def shutdown(sopel):


### PR DESCRIPTION
Long replaced by `client_secret`, along with slightly janky (because it auto-rewrites Sopel's config file, erasing comments) auto-migration code to move the old `secret` value to the new place where it belongs.

Was meant to be removed in 0.3.0, but we went through the whole 0.4.x series with this still present.