### PR TITLE
github: support inline references to issues/PRs in any repo

### DIFF
--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -134,7 +134,7 @@ def fetch_api_endpoint(bot, url):
 
 
 @plugin.find(
-    r'(?<!\S)(?:\b(?:(?P<user>{match_user})\/)?(?P<repo>{match_repo}))?#(?P<num>\d+)\b'
+    r'(?<![\w\/\.])(?:\b(?:(?P<user>{match_user})\/)?(?P<repo>{match_repo}))?(?<![\/\.])#(?P<num>\d+)\b'
     .format(match_user=githubUsername, match_repo=githubRepoSlug)
 )
 @plugin.require_chanmsg


### PR DESCRIPTION
This accepts `user/reponame#123` in all cases.

As before, if the current channel has a default repo (set using the `.gh-repo` command), `#123` will be treated as a reference to an issue or PR in the configured default repo. Additionally, `reponame#123` will now fill in the missing "username" portion from the configured default.

Implementing this feature required switching to named capture groups in all URL patterns, because the `user` and `reponame` portions of the inline references are optional. It seemed like a maintainability win, anyway, so even if I just missed thinking of a way to do it with numbered capture groups, I'm glad to have made the change anyway.