### PR TITLE
github: timestamp for issue/PR (+comment) output

### DIFF
--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -217,11 +217,13 @@ def issue_info(bot, trigger, match=None):
         ])
 
     # reunited once again; the rest of the output format is common
+    now = datetime.datetime.utcnow()  # can't use trigger.time until it becomes Aware in Sopel 8
+    created_at = from_utc(data['created_at'])
     response.extend([
         ' by ',
         data['user']['login'],
-        ', ',
-        format_time(bot.db, bot.config, None, None, trigger.sender, from_utc(data['created_at'])),
+        ', created ',
+        seconds_to_human((now - created_at).total_seconds()),
         ': ',
     ])
 

--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -220,7 +220,9 @@ def issue_info(bot, trigger, match=None):
     response.extend([
         ' by ',
         data['user']['login'],
-        ': '
+        ', ',
+        format_time(bot.db, bot.config, None, None, trigger.sender, from_utc(data['created_at'])),
+        ': ',
     ])
 
     if ('title' in data):


### PR DESCRIPTION
Little bit janky, more of a test than a final implementation. This really illustrates what I meant in https://github.com/sopel-irc/sopel-github/issues/121#issuecomment-1491114633 when I said the real challenge would be making the message format flow nicely.

_Will_ close #121 when finished…