### PR TITLE
github: add config & logic to skip too-short inline issue numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ the user. For example:
         https://github.com/sopel-irc/sopel-github
 ```
 
+### Nuisance reduction
+
+This plugin looks for bare references to issues/PRs the same way GitHub does in
+comments. If the current channel is associated with a repo, the minimum valid
+reference is e.g. `#1`, which is often unhelpful. Anecdotally, chat users talk
+about their number-one (or two, or three) favorite _something_ much more often
+than they reference the project's very oldest issues.
+
+For this reason, `sopel-github` ignores any single-digit bare references by
+default. Your installation can use the `shortest_bare_number` setting in the
+`[github]` config section to set a different minimum length.
+
 ### API Keys & Usage
 
 GitHub's API has some fairly lenient unauthorized request limits, but you may

--- a/sopel_modules/github/github.py
+++ b/sopel_modules/github/github.py
@@ -81,6 +81,7 @@ class GitHubSection(StaticSection):
     webhook_host = ValidatedAttribute('webhook_host', default='0.0.0.0')
     webhook_port = ValidatedAttribute('webhook_port', default='3333')
     external_url = ValidatedAttribute('external_url', default='http://your_ip_or_domain_here:3333')
+    shortest_bare_number = ValidatedAttribute('shortest_bare_number', int, default=2)
 
 
 def configure(config):
@@ -162,7 +163,11 @@ def issue_info(bot, trigger, match=None):
             # it's impossible to fill in the blank(s).
             return plugin.NOLIMIT
 
-        # By this point we are sure to have a channel repo set; start filling blanks.
+        # We do have a channel repo, but bare #numbers that are too short should be ignored.
+        if user is None and repo is None and len(num) < bot.config.github.shortest_bare_number:
+            return plugin.NOLIMIT
+
+        # All sanity checks done; start filling blanks.
         if user is None and repo is None:
             user, repo = channel_repo.split('/', 1)
         elif repo and not user:


### PR DESCRIPTION
Resolve #131, including a new config setting to override the mitigation if so desired.

The new config value is intentionally omitted from `configure()`, since for most users the default will be fine and it would be more confusing to try to explain the setting's purpose in a one-line prompt.

As it says in #131, a per-channel option might be helpful in the long term. But like I wrote in #136, more granular/nuanced controls for things will be easier to do after the plugin is de-spaghettified (long overdue work).